### PR TITLE
some cleanup

### DIFF
--- a/service.go
+++ b/service.go
@@ -48,10 +48,10 @@ type TunnelServiceHandlerOptions struct {
 	NoReverseTunnels bool
 	// If reverse tunnels are allowed, this callback may be configured to
 	// receive information when clients open a reverse tunnel.
-	OnReverseTunnelConnect func(ReverseTunnelChannel)
+	OnReverseTunnelOpen func(ReverseTunnelChannel)
 	// If reverse tunnels are allowed, this callback may be configured to
 	// receive information when reverse tunnels are torn down.
-	OnReverseTunnelDisconnect func(ReverseTunnelChannel)
+	OnReverseTunnelClose func(ReverseTunnelChannel)
 	// Optional function that accepts a reverse tunnel and returns an affinity
 	// key. The affinity key values can be used to look up outbound channels,
 	// for targeting calls to particular clients or groups of clients.
@@ -69,8 +69,8 @@ func NewTunnelServiceHandler(options TunnelServiceHandlerOptions) *TunnelService
 	return &TunnelServiceHandler{
 		handlers:                  grpchan.HandlerMap{},
 		noReverseTunnels:          options.NoReverseTunnels,
-		onReverseTunnelConnect:    options.OnReverseTunnelConnect,
-		onReverseTunnelDisconnect: options.OnReverseTunnelDisconnect,
+		onReverseTunnelConnect:    options.OnReverseTunnelOpen,
+		onReverseTunnelDisconnect: options.OnReverseTunnelClose,
 		affinityKey:               options.AffinityKey,
 		reverse:                   newReverseChannels(),
 		reverseByKey:              map[interface{}]*reverseChannels{},

--- a/tunnel_test.go
+++ b/tunnel_test.go
@@ -24,7 +24,8 @@ func TestTunnelServer(t *testing.T) {
 
 	ts := NewTunnelServiceHandler(TunnelServiceHandlerOptions{
 		AffinityKey: func(t ReverseTunnelChannel) any {
-			vals := t.RequestHeaders().Get("nesting-level")
+			md, _ := metadata.FromIncomingContext(t.Context())
+			vals := md.Get("nesting-level")
 			if len(vals) == 0 {
 				return ""
 			}


### PR DESCRIPTION
On writing other docs (more detailed README with examples), I realized some issues. There were callbacks whose names used the terms "connect" and "disconnect" even though other docs call these events "open" and "close".

Also, the `ReverseTunnelChannel` provided request headers and the peer. But it did not provide a way to access other possible values stored in the stream context by server interceptors. So the interface has been updated to allow for this.