### PR TITLE
add functions for getting tunnel metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -270,12 +270,12 @@ reverse tunnels:
   track the available tunnels. Each such tunnel is a channel that can be used to
   send RPCs to the corresponding network client.
 * `AffinityKey`: This is a function for grouping reverse tunnels. The function
-  is given a `ReverseTunnelChannel` and returns a key. The function has access
-  to the corresponding stream's context, from which it can query for properties
-  that may be useful for grouping -- such as the authenticated peer, request
-  headers provided when the tunnel was opened, and any other context values that
-  may have been populated by interceptors. All reverse tunnels with the same key
-  can be treated like a connection pool using the handler's
+  is given a `TunnelChannel` and returns a key. The function has access to the
+  corresponding stream's context, from which it can query for properties that
+  may be useful for grouping -- such as the authenticated peer, request headers
+  provided when the tunnel was opened, and any other context values that may
+  have been populated by interceptors. All reverse tunnels with the same key can
+  be treated like a connection pool using the handler's
   [`KeyAsChannel`](https://pkg.go.dev/github.com/jhump/grpctunnel#TunnelServiceHandler.KeyAsChannel)
   method.
 

--- a/reverse_server.go
+++ b/reverse_server.go
@@ -8,6 +8,7 @@ import (
 	"github.com/fullstorydev/grpchan"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/status"
 
 	"github.com/jhump/grpctunnel/tunnelpb"
@@ -89,7 +90,10 @@ func (s *ReverseTunnelServer) Serve(ctx context.Context, opts ...grpc.CallOption
 		return false, err
 	}
 	defer s.wg.Done()
-	err = serveTunnel(stream, s.handlers, s.isClosing)
+	// TODO: we don't have a way to access outgoing metadata that gets added by
+	//       client interceptors that may be run by the stub.
+	md, _ := metadata.FromOutgoingContext(ctx)
+	err = serveTunnel(stream, md, s.handlers, s.isClosing)
 	if err == context.Canceled && ctx.Err() == nil && s.isClosed() {
 		// If we get back a cancelled error, but the given context is not
 		// cancelled and this server is closed, then the cancellation was

--- a/tunnel_metadata.go
+++ b/tunnel_metadata.go
@@ -1,0 +1,60 @@
+package grpctunnel
+
+import (
+	"context"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/metadata"
+)
+
+type (
+	tunnelMetadataIncomingContextKey struct{}
+	tunnelMetadataOutgoingContextKey struct{}
+	tunnelChannelContextKey          struct{}
+)
+
+// TunnelMetadataFromIncomingContext provides server-side access to the request
+// metadata used to open a tunnel. This can be used from server interceptors or
+// handlers that are handling tunneled requests in a tunnel.
+func TunnelMetadataFromIncomingContext(ctx context.Context) (metadata.MD, bool) {
+	md, ok := ctx.Value(tunnelMetadataIncomingContextKey{}).(metadata.MD)
+	return md.Copy(), ok
+}
+
+// TunnelMetadataFromOutgoingContext provides client-side access to the request
+// metadata used to open a forward tunnel. This can be used from client
+// interceptors that are processing tunneled requests in a forward tunnel.
+//
+// For client interceptors in a reverse tunnel, you can use
+// [metadata.FromOutgoingContext] with the context passed to the interceptor or
+// handler.
+func TunnelMetadataFromOutgoingContext(ctx context.Context) (metadata.MD, bool) {
+	md, ok := ctx.Value(tunnelMetadataOutgoingContextKey{}).(metadata.MD)
+	return md.Copy(), ok
+}
+
+// TunnelChannelFromContext returns the TunnelChannel that is handling the given
+// request context. If the given context is not a client-side request context,
+// or if the channel for the request is not a tunnel, this will return nil.
+func TunnelChannelFromContext(ctx context.Context) TunnelChannel {
+	tc, _ := ctx.Value(tunnelChannelContextKey{}).(TunnelChannel)
+	return tc
+}
+
+// WithTunnelChannel provides the caller access to the specific TunnelChanel
+// that was used to send a tunneled RPC. This is similar to using
+// TunnelChannelFromContext except it can be used with unary RPCs, where the
+// invoker never has access to values added to the request context. When the RPC
+// completes, the given location will be updated with the channel that handled
+// the request. If the channel that handled the request was not a tunnel, the
+// location is left unchanged.
+//
+// The pointer must point to an allocated location. Passing a nil pointer will
+// result in a panic when an RPC is invoked with the returned option.
+func WithTunnelChannel(ch *TunnelChannel) grpc.CallOption {
+	return &tunnelChannelCallOption{ch: ch}
+}
+
+type tunnelChannelCallOption struct {
+	ch *TunnelChannel
+	grpc.EmptyCallOption
+}

--- a/tunnel_test.go
+++ b/tunnel_test.go
@@ -23,7 +23,7 @@ func TestTunnelServer(t *testing.T) {
 	var svr grpchantesting.TestServer
 
 	ts := NewTunnelServiceHandler(TunnelServiceHandlerOptions{
-		AffinityKey: func(t ReverseTunnelChannel) any {
+		AffinityKey: func(t TunnelChannel) any {
 			md, _ := metadata.FromIncomingContext(t.Context())
 			vals := md.Get("nesting-level")
 			if len(vals) == 0 {


### PR DESCRIPTION
For the server side, values in the context for the "open tunnel" RPC are also present in all tunneled RPC contexts. But the request headers used to create the tunnel may be overwritten by request headers for the tunneled RPC. So this provides a new method for access them (`TunnelMetadataFromIncomingContext`).

For the client side, the RPC context for tunneled calls is likely to be distinct/unrelated to the RPC context used to create the tunnel. And even if the tunneled context is a descendant, request headers may be overwritten by headers for the tunneled RPC. So this also provides a new method for this direction of access (`TunnelMetadataFromOutgoingContext`).

Finally, to access any other properties of the `TunnelChannel` or its context on the client side, this provides a way to extract the channel from the context, which is useful for streaming calls and client interceptors: `TunnelChannelFromContext`. For unary RPCs, this provides `WithTunnelChannel`. These two methods are similar to the use of `peer.FromContext` and `grpc.Peer` for these two situations, respectively.

This also removes `ReverseTunnelChannel` interface since it is actually the same as `TunnelChannel`. It embedded `TunnelChannel` and then defined a `Context() context.Context` method. But `TunnelChannel` already defines such a method, so the separate interface is not useful.