### PR TITLE
Adds concurrency test and updates code to address possible issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 .PHONY: ci
-ci: deps checkgofmt errcheck golint vet predeclared ineffassign staticcheck test
+ci: deps checkgofmt errcheck golint vet ineffassign staticcheck test
 
 .PHONY: deps
 deps:
@@ -36,11 +36,6 @@ staticcheck:
 ineffassign:
 	@go install github.com/gordonklaus/ineffassign@v0.0.0-20200309095847-7953dde2c7bf
 	ineffassign .
-
-.PHONY: predeclared
-predeclared:
-	@go install github.com/nishanths/predeclared@v0.2.2
-	predeclared ./...
 
 .PHONY: golint
 golint:

--- a/service.go
+++ b/service.go
@@ -117,6 +117,7 @@ func (s *TunnelServiceHandler) openTunnel(stream tunnelpb.TunnelService_OpenTunn
 	if len(s.handlers) == 0 {
 		return status.Error(codes.Unimplemented, "forward tunnels not supported")
 	}
+	stream = &threadSafeOpenTunnelServer{TunnelService_OpenTunnelServer: stream}
 	md, _ := metadata.FromIncomingContext(stream.Context())
 	return serveTunnel(stream, md, s.handlers, s.stopping.Load)
 }


### PR DESCRIPTION
* Need more synchronization in calls to tunnel streams since Go docs for grpc streams explicitly states that concurrent calls to `Send` and concurrent calls to `Recv` are not safe. (Though a call to `Send` that is concurrent with a call to `Recv` *is* safe.)
* Applies a fix that was found and patched in [jh/flow-control](https://github.com/jhump/grpctunnel/commit/66b346a15b2b3478d20aedbfdf8bf273263b69f0) branch related to non-sequential use of stream IDs.
* Unrelated: removed the predeclared checker because it has an internal error and appears to no longer be maintained.