### PR TITLE
Revert recent API change

### DIFF
--- a/internal/cmd/tunneltestsvr/main.go
+++ b/internal/cmd/tunneltestsvr/main.go
@@ -33,7 +33,7 @@ func main() {
 			return vals[0]
 		},
 	})
-	tunnelpb.RegisterTunnelServiceServer(svr, tunnelSvc)
+	tunnelpb.RegisterTunnelServiceServer(svr, tunnelSvc.Service())
 	gen.RegisterTunnelTestServiceServer(svr, &tunnelTester{tunnelSvc: tunnelSvc})
 
 	// Over the tunnel, we just expose this simple test service

--- a/tunnel_test.go
+++ b/tunnel_test.go
@@ -37,12 +37,12 @@ func TestTunnelServiceHandler(t *testing.T) {
 	grpchantesting.RegisterTestServiceServer(ts, &svr)
 	// recursive: tunnels can be run on top of tunnels
 	// (not realistic, but fun exercise to verify soundness of protocol)
-	tunnelpb.RegisterTunnelServiceServer(ts, ts)
+	tunnelpb.RegisterTunnelServiceServer(ts, ts.Service())
 
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err, "failed to listen")
 	gs := grpc.NewServer()
-	tunnelpb.RegisterTunnelServiceServer(gs, ts)
+	tunnelpb.RegisterTunnelServiceServer(gs, ts.Service())
 	serveDone := make(chan struct{})
 	go func() {
 		defer close(serveDone)
@@ -104,7 +104,7 @@ func runTests(ctx context.Context, t *testing.T, nested bool, cli tunnelpb.Tunne
 			revSvr := NewReverseTunnelServer(cli)
 			if !nested {
 				// we need this to run the nested/recursive tunnel test
-				tunnelpb.RegisterTunnelServiceServer(revSvr, ts)
+				tunnelpb.RegisterTunnelServiceServer(revSvr, ts.Service())
 			}
 			grpchantesting.RegisterTestServiceServer(revSvr, testSvr)
 			serveDone := make(chan struct{})
@@ -156,7 +156,7 @@ func TestTunnelServiceHandler_Concurrency(t *testing.T) {
 	l, err := net.Listen("tcp", "127.0.0.1:0")
 	require.NoError(t, err, "failed to listen")
 	gs := grpc.NewServer()
-	tunnelpb.RegisterTunnelServiceServer(gs, ts)
+	tunnelpb.RegisterTunnelServiceServer(gs, ts.Service())
 	serveDone := make(chan struct{})
 	go func() {
 		defer close(serveDone)


### PR DESCRIPTION
This undoes an API change made in #12. While it was a useful simplification, we're going to defer all exported API changes until _after_ a planned v0.3.0 (after flow-control support is implemented and released).

The API changes are primarily intended to prepare for a v1.0. There are several others that will be useful to make before sealing the API with a v1.0 release. (While they will all be backwards-incompatible, they should all be trivial for users to fix when upgrading to whatever release will include them.)